### PR TITLE
Add "minimum" to all 3.3.8 links and mentions

### DIFF
--- a/WCAG 2.2 URLs - Temporary Notes.txt
+++ b/WCAG 2.2 URLs - Temporary Notes.txt
@@ -7,7 +7,7 @@ https://www.w3.org/TR/WCAG22/#dragging-movements
 https://www.w3.org/TR/WCAG22/#target-size-minimum
 https://www.w3.org/TR/WCAG22/#consistent-help
 https://www.w3.org/TR/WCAG22/#redundant-entry
-https://www.w3.org/TR/WCAG22/#accessible-authentication
+https://www.w3.org/TR/WCAG22/#accessible-authentication-minimum
 https://www.w3.org/TR/WCAG22/#accessible-authentication-enhanced
 
 
@@ -18,7 +18,7 @@ SC 2.5.7 Dragging Movements (Level AA)
 SC 2.5.8 Target Size (Minimum) (Level AA)
 SC 3.2.6 Consistent Help (Level A)
 SC 3.3.7 Redundant Entry (Level A)
-SC 3.3.8 Accessible Authentication (Level AA)
+SC 3.3.8 Accessible Authentication (Minimum) (Level AA)
 SC 3.3.9 Accessible Authentication (Enhanced) (Level AAA)
 
 2.4.11
@@ -40,5 +40,5 @@ https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html
 https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html
 https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html
 https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html
-https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication.html
+https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html
 https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-enhanced.html

--- a/WCAG Docs/WCAG 2.2 SCs.kmmacros
+++ b/WCAG Docs/WCAG 2.2 SCs.kmmacros
@@ -391,11 +391,11 @@
 						AAABAs1ktgEAAAAAAAAAAAAA
 						</data>
 						<key>Text</key>
-						<string>SC 3.3.8 Accessible Authentication [AA] </string>
+						<string>SC 3.3.8 Accessible Authentication (Minimum) [AA] </string>
 					</dict>
 				</array>
 				<key>Name</key>
-				<string>3.3.8 Accessible Authentication [AA]</string>
+				<string>3.3.8 Accessible Authentication (Minimum) [AA]</string>
 				<key>Triggers</key>
 				<array>
 					<dict>
@@ -539,11 +539,11 @@
 						<key>TimeOutAbortsMacro</key>
 						<true/>
 						<key>URL</key>
-						<string>https://www.w3.org/TR/WCAG22/#accessible-authentication</string>
+						<string>https://www.w3.org/TR/WCAG22/#accessible-authentication-minimum</string>
 					</dict>
 				</array>
 				<key>Name</key>
-				<string>SC 3.3.8 Accessible Authentication [AA] !WCAG 2.2!</string>
+				<string>SC 3.3.8 Accessible Authentication (Minimum) [AA] !WCAG 2.2!</string>
 				<key>Triggers</key>
 				<array>
 					<dict>
@@ -1131,11 +1131,11 @@
 						<key>MacroActionType</key>
 						<string>InsertText</string>
 						<key>Text</key>
-						<string>&lt;a href="https://www.w3.org/TR/WCAG22/#accessible-authentication"&gt;SC 3.3.8 Accessible Authentication&lt;/a&gt;</string>
+						<string>&lt;a href="https://www.w3.org/TR/WCAG22/#accessible-authentication-minimum"&gt;SC 3.3.8 Accessible Authentication&lt;/a&gt;</string>
 					</dict>
 				</array>
 				<key>Name</key>
-				<string>SC 3.3.8 Accessible Authentication [AA] !WCAG 2.2!</string>
+				<string>SC 3.3.8 Accessible Authentication (Minimum) [AA] !WCAG 2.2!</string>
 				<key>Triggers</key>
 				<array>
 					<dict>
@@ -2306,7 +2306,7 @@
 					</dict>
 				</array>
 				<key>Name</key>
-				<string>3.3.8 Accessible Authentication [AA]</string>
+				<string>3.3.8 Accessible Authentication (Minimum) [AA]</string>
 				<key>Triggers</key>
 				<array>
 					<dict>
@@ -2409,11 +2409,11 @@
 						<key>MacroActionType</key>
 						<string>InsertText</string>
 						<key>Text</key>
-						<string>&lt;a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication.html"&gt;SC 3.3.8 Accessible Authentication&lt;/a&gt;</string>
+						<string>&lt;a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html"&gt;SC 3.3.8 Accessible Authentication&lt;/a&gt;</string>
 					</dict>
 				</array>
 				<key>Name</key>
-				<string>🆄 SC 3.3.8 Accessible Authentication [AA] - Understanding (Markdown link) !WCAG 2.2!</string>
+				<string>🆄 SC 3.3.8 Accessible Authentication (Minimum) [AA] - Understanding (Markdown link) !WCAG 2.2!</string>
 				<key>Triggers</key>
 				<array>
 					<dict>
@@ -2584,11 +2584,11 @@
 						<key>MacroActionType</key>
 						<string>InsertText</string>
 						<key>Text</key>
-						<string>[SC 3.3.8 Accessible Authentication (Level AA)](https://www.w3.org/TR/WCAG22/#accessible-authentication)</string>
+						<string>[SC 3.3.8 Accessible Authentication (Minimum) (Level AA)](https://www.w3.org/TR/WCAG22/#accessible-authentication-minimum)</string>
 					</dict>
 				</array>
 				<key>Name</key>
-				<string>SC 3.3.8 Accessible Authentication [AA] !WCAG 2.2!</string>
+				<string>SC 3.3.8 Accessible Authentication (Minimum) [AA] !WCAG 2.2!</string>
 				<key>Triggers</key>
 				<array>
 					<dict>
@@ -2767,11 +2767,11 @@
 						<key>TimeOutAbortsMacro</key>
 						<true/>
 						<key>URL</key>
-						<string>https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication.html</string>
+						<string>https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html</string>
 					</dict>
 				</array>
 				<key>Name</key>
-				<string>🆄 3.3.8 Accessible Authentication [AA] !WCAG 2.2!</string>
+				<string>🆄 3.3.8 Accessible Authentication (Minimum) [AA] !WCAG 2.2!</string>
 				<key>Triggers</key>
 				<array>
 					<dict>
@@ -2872,11 +2872,11 @@
 						<key>MacroActionType</key>
 						<string>InsertText</string>
 						<key>Text</key>
-						<string>[SC 3.3.8 Accessible Authentication (Level AA)](https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication.html)</string>
+						<string>[SC 3.3.8 Accessible Authentication (Minimum) (Level AA)](https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html)</string>
 					</dict>
 				</array>
 				<key>Name</key>
-				<string>🆄 SC 3.3.8 Accessible Authentication [AA] 🅼🅳 !WCAG 2.2!</string>
+				<string>🆄 SC 3.3.8 Accessible Authentication (Minimum) [AA] 🅼🅳 !WCAG 2.2!</string>
 				<key>Triggers</key>
 				<array>
 					<dict>
@@ -3359,11 +3359,11 @@
 						<key>MacroActionType</key>
 						<string>InsertText</string>
 						<key>Text</key>
-						<string>https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication.html</string>
+						<string>https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html</string>
 					</dict>
 				</array>
 				<key>Name</key>
-				<string>🆄 SC 3.3.8 Accessible Authentication [AA] (URL) !WCAG 2.2!</string>
+				<string>🆄 SC 3.3.8 Accessible Authentication (Minimum) [AA] (URL) !WCAG 2.2!</string>
 				<key>Triggers</key>
 				<array>
 					<dict>
@@ -3675,11 +3675,11 @@
 						<key>MacroActionType</key>
 						<string>InsertText</string>
 						<key>Text</key>
-						<string>https://www.w3.org/TR/WCAG22/#accessible-authentication</string>
+						<string>https://www.w3.org/TR/WCAG22/#accessible-authentication-minimum</string>
 					</dict>
 				</array>
 				<key>Name</key>
-				<string>SC 3.3.8 Accessible Authentication [AA] (URL) !WCAG 2.2!</string>
+				<string>SC 3.3.8 Accessible Authentication (Minimum) [AA] (URL) !WCAG 2.2!</string>
 				<key>Triggers</key>
 				<array>
 					<dict>


### PR DESCRIPTION
I noticed that the Keyboard Maestro macros for [3.3.8 Accessible Authentication (Minimum) (AA)](https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html) weren't resolving. This PR adds `(Minimum)` to all 3.3.8 mentions and `-minimum` to all 3.3.8 URLs.

Thank you for creating and sharing this! I now have muscle memory for the `1.1.1--` shortcut convention and rely on it daily.